### PR TITLE
Add site info on login page

### DIFF
--- a/app/static/less/common.less
+++ b/app/static/less/common.less
@@ -69,7 +69,7 @@ html,body {
     flex-direction: column;
     text-align: center;
     align-items: center;
-    height: 100%;
+    min-height: 100%;
     width: 100%;
 }
 
@@ -102,6 +102,13 @@ html,body {
 .logo-holder {
     margin-top: 10rem;
     margin-bottom: 2rem;
+
+    @media @tablet {
+        margin-top: 2rem;
+    }
+    @media @mobile {
+        margin-top: 2rem;
+    }
 
     .main-logo {
         width: 50%;

--- a/app/templates/prompt_login/prompt_login.html
+++ b/app/templates/prompt_login/prompt_login.html
@@ -12,7 +12,7 @@
   </div>
 
   <div class="font-weight-bold text-white mb-5 mx-4">
-    <p>cubers.io is a web app where you can participate in WCA-style speedcubing competitions!</p>
+    <p>Participate in WCA-style speedcubing competitions!</p>
   </div>
 
   <div class="login_button_holder">
@@ -26,7 +26,7 @@
     </a>
   </div>
 
-  <div class="card-deck text-center my-5 mx-4">
+  <div class="card-deck my-5 mx-4">
 
     <div class="card mb-4">
       <div class="card-header">
@@ -36,8 +36,8 @@
         <ul class="list-group list-group-flush mb-2">
           <li class="list-group-item">All WCA events.</li>
           <li class="list-group-item">Rotating selection of bonus non-WCA events.</li>
-          <li class="list-group-item">Leaderboards and Rankings.</li>
-          <li class="list-group-item">Customizable and optional timer. <br>Compete using your favorite timer and only input times.</li>
+          <li class="list-group-item">Leaderboards and rankings.</li>
+          <li class="list-group-item">Use the built-in customizable timer, <br> or use your own and enter results directly.</li>
         </ul>
       </div>
     </div>
@@ -50,7 +50,7 @@
         <ul class="list-group list-group-flush mb-2">
           <li class="list-group-item">Solves are automatically saved.</li>
           <li class="list-group-item">Return later and pick up where you left off.</li>
-          <li class="list-group-item">Automatic Reddit comment generation and submission.</li>
+          <li class="list-group-item">Reddit integration provides weekly notifications of<br>new competitions and statistics about your solves.</li>
           <li class="list-group-item">Track your performance with participation history and PBs.</li>
         </ul>
       </div>

--- a/app/templates/prompt_login/prompt_login.html
+++ b/app/templates/prompt_login/prompt_login.html
@@ -10,6 +10,11 @@
   <div class="logo-holder">
     <img class="main-logo" src="./static/images/cubersio_logo_light.png">
   </div>
+
+  <div class="font-weight-bold text-white mb-5 mx-4">
+    <p>cubers.io is a web app where you can participate in WCA-style speedcubing competitions!</p>
+  </div>
+
   <div class="login_button_holder">
     <a href="{{ url_for('reddit_login') }}" class="btn btn-lg btn-block btn-social btn-github">
       <span class="fab fa-reddit-alien"></span>
@@ -19,6 +24,38 @@
       <span><img class="wca-login-img" src="/static/images/wca_color.png" /></span>
       Sign in with WCA
     </a>
+  </div>
+
+  <div class="card-deck text-center my-5 mx-4">
+
+    <div class="card mb-4">
+      <div class="card-header">
+        <h4>Weekly Competitions</h4>
+      </div>
+      <div class="card-body">
+        <ul class="list-group list-group-flush mb-2">
+          <li class="list-group-item">All WCA events.</li>
+          <li class="list-group-item">Rotating selection of bonus non-WCA events.</li>
+          <li class="list-group-item">Leaderboards and Rankings.</li>
+          <li class="list-group-item">Customizable and optional timer. <br>Compete using your favorite timer and only input times.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="card mb-4">
+      <div class="card-header">
+        <h4>Ease of use</h4>
+      </div>
+      <div class="card-body">
+        <ul class="list-group list-group-flush mb-2">
+          <li class="list-group-item">Solves are automatically saved.</li>
+          <li class="list-group-item">Return later and pick up where you left off.</li>
+          <li class="list-group-item">Automatic Reddit comment generation and submission.</li>
+          <li class="list-group-item">Track your performance with participation history and PBs.</li>
+        </ul>
+      </div>
+    </div>
+
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This adds an onto the login page a few pieces of information about cubers.io.
I assume this is completely up to changes and represents only an initial try on the issue.

![draft_info_on_login](https://user-images.githubusercontent.com/29216027/95237162-3ea3fa00-07de-11eb-89eb-3624e13bc251.png)

![mobile_preview](https://user-images.githubusercontent.com/29216027/95251511-0b6b6600-07f2-11eb-87a1-b313e0933464.png)


