### PR TITLE
[#124] Indicate that user has already logged in with WCA

### DIFF
--- a/app/persistence/settings_manager.py
+++ b/app/persistence/settings_manager.py
@@ -21,6 +21,9 @@ class SettingCode():
     # Hidden events
     HIDDEN_EVENTS = 'hidden_events'
 
+    # WCA id settings
+    SHOW_WCA_ID = 'show_wca_id'
+
     # Reddit related settings
     REDDIT_COMP_NOTIFY    = 'reddit_comp_notify'
     REDDIT_RESULTS_NOTIFY = 'reddit_results_notify'
@@ -159,6 +162,13 @@ SETTING_INFO_MAP = {
         validator     = int_list_validator,
         setting_type  = SettingType.EVENT_ID_LIST,
         default_value = ""
+    ),
+
+    SettingCode.SHOW_WCA_ID: SettingInfo(
+        title         = "Show WCA ID on public profile",
+        validator     = boolean_validator,
+        setting_type  = SettingType.BOOLEAN,
+        default_value = FALSE_STR
     ),
 
     SettingCode.HIDE_SCRAMBLE_PREVIEW: SettingInfo(

--- a/app/routes/user/profile_routes.py
+++ b/app/routes/user/profile_routes.py
@@ -15,6 +15,7 @@ from app.persistence.user_results_manager import get_user_completed_solves_count
     get_user_medals_count
 from app.persistence.events_manager import get_events_id_name_mapping
 from app.persistence.user_site_rankings_manager import get_site_rankings_for_user
+from app.persistence.settings_manager import get_setting_for_user, SettingCode
 
 # -------------------------------------------------------------------------------------------------
 
@@ -84,6 +85,10 @@ def profile(username):
     # Set a flag indicating if this page view is for a user viewing another user's page
     viewing_self = user.username == current_user.username
 
+    # Check if user has set WCA ID to be public
+    show_wca_id_str = get_setting_for_user(user.id, SettingCode.SHOW_WCA_ID)
+    show_wca_id_bool = True if show_wca_id_str == 'true' else False
+
     # Set flags to indicate if user is missing a Reddit/WCA profile association
     missing_wca_association = viewing_self and username == user.reddit_id and not user.wca_id
     missing_reddit_association = viewing_self and username == user.wca_id and not user.reddit_id
@@ -95,7 +100,7 @@ def profile(username):
                            sor_wca=sor_wca, sor_non_wca=sor_non_wca, gold_count=gold_count,
                            silver_count=silver_count, bronze_count=bronze_count,
                            viewing_self=viewing_self, kinch_all=kinch_all, kinch_wca=kinch_wca,
-                           kinch_non_wca=kinch_non_wca,
+                           kinch_non_wca=kinch_non_wca, show_wca_id=show_wca_id_bool,
                            missing_wca_association=missing_wca_association,
                            missing_reddit_association=missing_reddit_association)
 

--- a/app/routes/user/settings_routes.py
+++ b/app/routes/user/settings_routes.py
@@ -28,6 +28,10 @@ HIDDEN_EVENT_SETTING = [
     SettingCode.HIDDEN_EVENTS
 ]
 
+SHOW_WCA_ID_SETTING = [
+    SettingCode.SHOW_WCA_ID
+]
+
 CUSTOM_CUBE_COLOR_SETTINGS = [
     SettingCode.USE_CUSTOM_CUBE_COLORS,
     SettingCode.CUSTOM_CUBE_COLOR_U,
@@ -68,7 +72,7 @@ REDDIT_SETTINGS = [
 ]
 
 __ALL_SETTINGS = REDDIT_SETTINGS + CUSTOM_CUBE_COLOR_SETTINGS + CUSTOM_PYRAMINX_COLOR_SETTINGS
-__ALL_SETTINGS += HIDDEN_EVENT_SETTING + CUSTOM_MEGAMINX_COLOR_SETTINGS + TIMER_SETTINGS
+__ALL_SETTINGS += HIDDEN_EVENT_SETTING + SHOW_WCA_ID_SETTING + CUSTOM_MEGAMINX_COLOR_SETTINGS + TIMER_SETTINGS
 
 # -------------------------------------------------------------------------------------------------
 
@@ -92,6 +96,7 @@ def __handle_get(user):
     settings_sections = OrderedDict([
         ("Timer Settings",        [s for s in all_settings if s.code in set(TIMER_SETTINGS)]),
         ("Reddit Settings",       [s for s in all_settings if s.code in set(REDDIT_SETTINGS)]),
+        ("WCA Settings",         [s for s in all_settings if s.code in set(SHOW_WCA_ID_SETTING)]),
         ("Hidden Events",         [s for s in all_settings if s.code in set(HIDDEN_EVENT_SETTING)]),
         ("Custom Cube Color",     [s for s in all_settings if s.code in set(CUSTOM_CUBE_COLOR_SETTINGS)]),
         ("Custom Pyraminx Color", [s for s in all_settings if s.code in set(CUSTOM_PYRAMINX_COLOR_SETTINGS)]),
@@ -105,6 +110,11 @@ def __handle_get(user):
     # If the user doesn't have Reddit account info, omit the Reddit Settings section
     if not user.reddit_id:
         del settings_sections['Reddit Settings']
+
+    # If the user doesn't have WCA account info, omit the WCA Settings section
+    if not user.wca_id:
+        del settings_sections['WCA Settings']
+    
 
     # Disable the relevant settings, if other setting values affect them
     disabled_settings = list()

--- a/app/templates/user/profile.html
+++ b/app/templates/user/profile.html
@@ -85,7 +85,7 @@
                 {% endif %}
             {% else %}
                 <div class="flex-center-all"><h3 class="text-center">{{ user.username }}</h3></div>
-                {% if missing_wca_association %}
+                {% if missing_wca_association and viewing_self %}
                 <div class="flex-center-all">
                     <a href="{{ url_for('wca_assoc') }}" class="btn btn-lg btn-block btn-social btn-wca btn-force-btn-width">
                         <span><img class="wca-login-img" src="/static/images/wca_color.png" /></span>
@@ -93,7 +93,13 @@
                     </a>
                     <span style="font-weight: normal; padding-left: 5px;" class="fas fa-question-circle spacer" data-toggle="tooltip" data-placement="bottom" title="{{ wca_assoc_explanation }}"></span>
                 </div>
+                {% elif not missing_wca_association and (viewing_self or show_wca_id) %}
+                <div class="flex-center-all">
+                    <span><img class="wca-login-img" src="/static/images/wca_color.png" /></span>
+                    <h3 class="text-center ml-2">{{ user.wca_id }}</h3>
+                </div>
                 {% endif %}
+
                 {% if missing_reddit_association %}
                 <div class="flex-center-all">
                     <a href="{{ url_for('reddit_assoc') }}" class="btn btn-lg btn-block btn-social btn-github btn-force-btn-width">


### PR DESCRIPTION
This pull request adds the following changes:
- Indicate that a user has already logged in with WCA by showing the user's WCA id at their profile page
- A new setting to let users decide if they want to show their WCA id on their public profile