### PR TITLE
Fix cubers.io hyperlink not linking to website in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # cubers.io
 
-[cubers.io](https//www.cubers.io) is a web app where you can participate in [WCA](https://www.worldcubeassociation.org)-style speedcubing competitions every week!
+[cubers.io](https://www.cubers.io) is a web app where you can participate in [WCA](https://www.worldcubeassociation.org)-style speedcubing competitions every week!
 
 Each weekly competition holds every WCA event, as well as a rotating selection of bonus events which you can't find in any official competition.
 
 ## Contributing to cubers.io
 
-Are you both a software developer **and** a cuber, and would like to contribute to [cubers.io](https//www.cubers.io)? If so, please checkout the [contribution readme](https://github.com/euphwes/cubers.io/blob/main/contributing.md).
+Are you both a software developer **and** a cuber, and would like to contribute to [cubers.io](https://www.cubers.io)? If so, please checkout the [contribution readme](https://github.com/euphwes/cubers.io/blob/main/contributing.md).
 
 ## Features
 


### PR DESCRIPTION
The cubers.io hyperlink in the readme was linked to `https//www.cubers.io` instead of `https://www.cubers.io`, which was making it redirect to `https://github.com/euphwes/cubers.io/blob/main/https/www.cubers.io` instead of going to the actual website.

Sorry if that was done intentionally.